### PR TITLE
Fix/345 unpadding

### DIFF
--- a/bonsai/modules/networks/bonsai_nets.py
+++ b/bonsai/modules/networks/bonsai_nets.py
@@ -7,6 +7,9 @@ from bonsai.modules.networks.components.layer import TransformerLayer
 
 _FLASH_ATTENTION_AVAILABLE = importlib.util.find_spec("flash_attn") is not None
 
+if _FLASH_ATTENTION_AVAILABLE:
+    from flash_attn.bert_padding import pad_input, unpad_input
+
 
 class BonsaiBase(nn.Module):
     def __init__(
@@ -73,19 +76,62 @@ class BonsaiBase(nn.Module):
             segment=batch["segment"],
         )
 
-        # SDPA requires a broadcasted attention mask
-        if self.hparams["attn_type"] == "sdpa" and not self.hparams["causal"]:
+        x = self.drop(x)
+
+        attn_type = self.hparams["attn_type"]
+        causal = self.hparams["causal"]
+
+        if attn_type == "flash":
+            # unpad_input expects shape (batch, seqlen) with
+            # 1/True for real tokens and 0/False for padding.
+            attention_mask = batch["attention_mask"].bool()
+
+            batch_size, padded_seqlen = x.shape[:2]
+
+            # x:
+            # (batch, padded_seqlen, hidden_size)
+            # -> (total_valid_tokens, hidden_size)
+            (
+                x,
+                indices,
+                cu_seqlens,
+                max_seqlen,
+                _,
+            ) = unpad_input(x, attention_mask)
+
+            for layer in self.layers:
+                x = layer(
+                    x,
+                    cu_seqlens=cu_seqlens,
+                    max_seqlen=max_seqlen,
+                )
+
+            x = self.layernorm(x)
+
+            # x:
+            # (total_valid_tokens, hidden_size)
+            # -> (batch, padded_seqlen, hidden_size)
+            x = pad_input(
+                x,
+                indices,
+                batch_size,
+                padded_seqlen,
+            )
+
+            return x
+
+        # Existing SDPA path.
+        if attn_type == "sdpa" and not causal:
             attn_mask = batch["attention_mask"][:, None, None, :]
         else:
             attn_mask = None
 
-        x = self.drop(x)
         for layer in self.layers:
             x = layer(
                 x,
                 attn_mask=attn_mask,
-                cu_seqlens=batch.get("cu_seqlens"),
             )
+
         x = self.layernorm(x)
 
         return x

--- a/bonsai/modules/networks/bonsai_nets.py
+++ b/bonsai/modules/networks/bonsai_nets.py
@@ -69,16 +69,6 @@ class BonsaiBase(nn.Module):
         }
 
     def forward(self, batch):
-        if self.hparams["attn_type"] == "flash":
-            return self.forward_flash(batch)
-        elif self.hparams["attn_type"] == "sdpa" and not self.hparams["causal"]:
-            return self.forward_sdpa(batch)
-        else:
-            raise ValueError(
-                f"Invalid attention type: {self.hparams['attn_type']}. Only 'flash' and non-causal 'sdpa' are supported."
-            )
-
-    def forward_sdpa(self, batch):
         x = self.embeddings(
             code=batch["code"],
             age=batch["age"],
@@ -88,7 +78,17 @@ class BonsaiBase(nn.Module):
 
         x = self.drop(x)
 
-        attn_mask = batch["attention_mask"][:, None, None, :]
+        if self.hparams["attn_type"] == "flash":
+            return self.forward_flash(x, batch["attention_mask"])
+        elif self.hparams["attn_type"] == "sdpa" and not self.hparams["causal"]:
+            return self.forward_sdpa(x, batch["attention_mask"])
+        else:
+            raise ValueError(
+                f"Invalid attention type: {self.hparams['attn_type']}. Only 'flash' and non-causal 'sdpa' are supported."
+            )
+
+    def forward_sdpa(self, x, attn_mask):
+        attn_mask = attn_mask[:, None, None, :]
 
         for layer in self.layers:
             x = layer(x, attn_mask=attn_mask)
@@ -97,19 +97,10 @@ class BonsaiBase(nn.Module):
 
         return x
 
-    def forward_flash(self, batch):
-        x = self.embeddings(
-            code=batch["code"],
-            age=batch["age"],
-            abspos=batch["abspos"],
-            segment=batch["segment"],
-        )
-
-        x = self.drop(x)
-
+    def forward_flash(self, x, attn_mask):
         batch_size, padded_seqlen = x.shape[:2]
         (x, indices, cu_seqlens, max_seqlen, _) = unpad_input(
-            x, batch["attention_mask"]
+            x, attn_mask
         )  # x: (batch, padded_seqlen, hidden_size) -> (total_valid_tokens, hidden_size)
 
         for layer in self.layers:

--- a/bonsai/modules/networks/bonsai_nets.py
+++ b/bonsai/modules/networks/bonsai_nets.py
@@ -69,6 +69,16 @@ class BonsaiBase(nn.Module):
         }
 
     def forward(self, batch):
+        if self.hparams["attn_type"] == "flash":
+            return self.forward_flash(batch)
+        elif self.hparams["attn_type"] == "sdpa" and not self.hparams["causal"]:
+            return self.forward_sdpa(batch)
+        else:
+            raise ValueError(
+                f"Invalid attention type: {self.hparams['attn_type']}. Only 'flash' and non-causal 'sdpa' are supported."
+            )
+
+    def forward_sdpa(self, batch):
         x = self.embeddings(
             code=batch["code"],
             age=batch["age"],
@@ -78,37 +88,38 @@ class BonsaiBase(nn.Module):
 
         x = self.drop(x)
 
-        # FlashAttention requires unpadded input and cu_seqlens for variable-length sequences
-        if self.hparams["attn_type"] == "flash":
-            batch_size, padded_seqlen = x.shape[:2]
-            (x, indices, cu_seqlens, max_seqlen, _) = unpad_input(
-                x, batch["attention_mask"]
-            )  # x: (batch, padded_seqlen, hidden_size) -> (total_valid_tokens, hidden_size)
-            attn_mask = None  # Flash attention does not require an attention mask
-        # SDPA requires a broadcasted attention mask
-        elif self.hparams["attn_type"] == "sdpa" and not self.hparams["causal"]:
-            attn_mask = batch["attention_mask"][:, None, None, :]
-            cu_seqlens, max_seqlen = None, None
-
-        else:
-            raise ValueError(
-                "Invalid attention setup. Only non-causal SDPA and FlashAttention are supported."
-            )
+        attn_mask = batch["attention_mask"][:, None, None, :]
 
         for layer in self.layers:
-            x = layer(
-                x,
-                attn_mask=attn_mask,
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-            )
+            x = layer(x, attn_mask=attn_mask)
 
         x = self.layernorm(x)
 
-        if self.hparams["attn_type"] == "flash":
-            x = pad_input(
-                x, indices, batch_size, padded_seqlen
-            )  # x: (total_valid_tokens, hidden_size) -> (batch, padded_seqlen, hidden_size)
+        return x
+
+    def forward_flash(self, batch):
+        x = self.embeddings(
+            code=batch["code"],
+            age=batch["age"],
+            abspos=batch["abspos"],
+            segment=batch["segment"],
+        )
+
+        x = self.drop(x)
+
+        batch_size, padded_seqlen = x.shape[:2]
+        (x, indices, cu_seqlens, max_seqlen, _) = unpad_input(
+            x, batch["attention_mask"]
+        )  # x: (batch, padded_seqlen, hidden_size) -> (total_valid_tokens, hidden_size)
+
+        for layer in self.layers:
+            x = layer(x, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+
+        x = self.layernorm(x)
+
+        x = pad_input(
+            x, indices, batch_size, padded_seqlen
+        )  # x: (total_valid_tokens, hidden_size) -> (batch, padded_seqlen, hidden_size)
 
         return x
 

--- a/bonsai/modules/networks/bonsai_nets.py
+++ b/bonsai/modules/networks/bonsai_nets.py
@@ -78,61 +78,37 @@ class BonsaiBase(nn.Module):
 
         x = self.drop(x)
 
-        attn_type = self.hparams["attn_type"]
-        causal = self.hparams["causal"]
-
-        if attn_type == "flash":
-            # unpad_input expects shape (batch, seqlen) with
-            # 1/True for real tokens and 0/False for padding.
-            attention_mask = batch["attention_mask"].bool()
-
+        # FlashAttention requires unpadded input and cu_seqlens for variable-length sequences
+        if self.hparams["attn_type"] == "flash":
             batch_size, padded_seqlen = x.shape[:2]
-
-            # x:
-            # (batch, padded_seqlen, hidden_size)
-            # -> (total_valid_tokens, hidden_size)
-            (
-                x,
-                indices,
-                cu_seqlens,
-                max_seqlen,
-                _,
-            ) = unpad_input(x, attention_mask)
-
-            for layer in self.layers:
-                x = layer(
-                    x,
-                    cu_seqlens=cu_seqlens,
-                    max_seqlen=max_seqlen,
-                )
-
-            x = self.layernorm(x)
-
-            # x:
-            # (total_valid_tokens, hidden_size)
-            # -> (batch, padded_seqlen, hidden_size)
-            x = pad_input(
-                x,
-                indices,
-                batch_size,
-                padded_seqlen,
-            )
-
-            return x
-
-        # Existing SDPA path.
-        if attn_type == "sdpa" and not causal:
+            (x, indices, cu_seqlens, max_seqlen, _) = unpad_input(
+                x, batch["attention_mask"]
+            )  # x: (batch, padded_seqlen, hidden_size) -> (total_valid_tokens, hidden_size)
+            attn_mask = None  # Flash attention does not require an attention mask
+        # SDPA requires a broadcasted attention mask
+        elif self.hparams["attn_type"] == "sdpa" and not self.hparams["causal"]:
             attn_mask = batch["attention_mask"][:, None, None, :]
+            cu_seqlens, max_seqlen = None, None
+
         else:
-            attn_mask = None
+            raise ValueError(
+                "Invalid attention setup. Only non-causal SDPA and FlashAttention are supported."
+            )
 
         for layer in self.layers:
             x = layer(
                 x,
                 attn_mask=attn_mask,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
             )
 
         x = self.layernorm(x)
+
+        if self.hparams["attn_type"] == "flash":
+            x = pad_input(
+                x, indices, batch_size, padded_seqlen
+            )  # x: (total_valid_tokens, hidden_size) -> (batch, padded_seqlen, hidden_size)
 
         return x
 

--- a/bonsai/modules/networks/components/layer.py
+++ b/bonsai/modules/networks/components/layer.py
@@ -54,8 +54,6 @@ class TransformerLayer(nn.Module):
             )
         )
 
-        x = x + self.resid_dropout(
-            self.mlp(self.ln2(x))
-        )
+        x = x + self.resid_dropout(self.mlp(self.ln2(x)))
 
         return x

--- a/bonsai/modules/networks/components/layer.py
+++ b/bonsai/modules/networks/components/layer.py
@@ -38,10 +38,24 @@ class TransformerLayer(nn.Module):
         self.ln2 = nn.LayerNorm(hidden_size, bias=bias)
         self.mlp = Mlp(hidden_size, bias1=bias, bias2=bias)
 
-    def forward(self, x, attn_mask=None, cu_seqlens=None):
-        # LN -> MHA -> Dropout -> Add -> LN -> MLP -> Dropout -> Add
+    def forward(
+        self,
+        x,
+        attn_mask=None,
+        cu_seqlens=None,
+        max_seqlen=None,
+    ):
         x = x + self.resid_dropout(
-            self.mha(self.ln1(x), attn_mask=attn_mask, cu_seqlens=cu_seqlens)
+            self.mha(
+                self.ln1(x),
+                attn_mask=attn_mask,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
         )
-        x = x + self.resid_dropout(self.mlp(self.ln2(x)))
+
+        x = x + self.resid_dropout(
+            self.mlp(self.ln2(x))
+        )
+
         return x

--- a/bonsai/modules/networks/components/layer.py
+++ b/bonsai/modules/networks/components/layer.py
@@ -38,13 +38,7 @@ class TransformerLayer(nn.Module):
         self.ln2 = nn.LayerNorm(hidden_size, bias=bias)
         self.mlp = Mlp(hidden_size, bias1=bias, bias2=bias)
 
-    def forward(
-        self,
-        x,
-        attn_mask=None,
-        cu_seqlens=None,
-        max_seqlen=None,
-    ):
+    def forward(self, x, attn_mask=None, cu_seqlens=None, max_seqlen=None):
         # LN -> MHA -> Dropout -> Add -> LN -> MLP -> Dropout -> Add
         x = x + self.resid_dropout(
             self.mha(

--- a/bonsai/modules/networks/components/layer.py
+++ b/bonsai/modules/networks/components/layer.py
@@ -45,6 +45,7 @@ class TransformerLayer(nn.Module):
         cu_seqlens=None,
         max_seqlen=None,
     ):
+        # LN -> MHA -> Dropout -> Add -> LN -> MLP -> Dropout -> Add
         x = x + self.resid_dropout(
             self.mha(
                 self.ln1(x),

--- a/bonsai/modules/networks/components/mha_fa.py
+++ b/bonsai/modules/networks/components/mha_fa.py
@@ -34,17 +34,9 @@ class FlashMultiHeadAttention(nn.Module):
         qkv = self.Wqkv(x)
         qkv = qkv.view(total_tokens, 3, self.num_heads, self.head_dim)
 
-        qkv = self.rotary_embedding(
-            qkv,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
-        )
+        qkv = self.rotary_embedding(qkv, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
 
-        y = self.self_attn(
-            qkv,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
-        )
+        y = self.self_attn(qkv, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
 
         y = y.reshape(total_tokens, hidden_dim)
         return self.out_proj(y)

--- a/bonsai/modules/networks/components/mha_fa.py
+++ b/bonsai/modules/networks/components/mha_fa.py
@@ -14,7 +14,6 @@ class FlashMultiHeadAttention(nn.Module):
         )
         self.num_heads = num_heads
         self.head_dim = hidden_size // num_heads
-        self.max_seqlen = max_seqlen
 
         self.Wqkv = nn.Linear(hidden_size, hidden_size * 3, bias=bias)
         self.rotary_embedding = FlashRotaryEmbedding(dim=self.head_dim)
@@ -26,63 +25,26 @@ class FlashMultiHeadAttention(nn.Module):
     def forward(
         self,
         x,
-        cu_seqlens=None,
-        max_seqlen=None,
+        cu_seqlens,
+        max_seqlen,
         **kwargs,
     ):
-        if cu_seqlens is not None:
-            # Unpadded / variable-length path.
-            #
-            # x shape:
-            # (total_valid_tokens, hidden_size)
-            total_tokens, hidden_dim = x.shape
-
-            qkv = self.Wqkv(x)
-            qkv = qkv.view(
-                total_tokens,
-                3,
-                self.num_heads,
-                self.head_dim,
-            )
-
-            # Prefer the actual longest sequence in this batch.
-            if max_seqlen is None:
-                max_seqlen = self.max_seqlen
-
-            qkv = self.rotary_embedding(
-                qkv,
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-            )
-
-            y = self.self_attn(
-                qkv,
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-            )
-
-            y = y.reshape(total_tokens, hidden_dim)
-            return self.out_proj(y)
-
-        # Existing padded path.
-        batch_size, seqlen, hidden_dim = x.shape
+        total_tokens, hidden_dim = x.shape
 
         qkv = self.Wqkv(x)
-        qkv = qkv.view(
-            batch_size,
-            seqlen,
-            3,
-            self.num_heads,
-            self.head_dim,
-        )
+        qkv = qkv.view(total_tokens, 3, self.num_heads, self.head_dim)
 
         qkv = self.rotary_embedding(
             qkv,
-            cu_seqlens=None,
-            max_seqlen=seqlen,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
         )
 
-        y = self.self_attn(qkv)
+        y = self.self_attn(
+            qkv,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
 
-        y = y.reshape(batch_size, seqlen, hidden_dim)
+        y = y.reshape(total_tokens, hidden_dim)
         return self.out_proj(y)

--- a/bonsai/modules/networks/components/mha_fa.py
+++ b/bonsai/modules/networks/components/mha_fa.py
@@ -23,19 +23,66 @@ class FlashMultiHeadAttention(nn.Module):
         )
         self.out_proj = nn.Linear(hidden_size, hidden_size, bias=bias)
 
-    def forward(self, x, cu_seqlens=None, **kwargs):
-        bs, seqlen, hidden_dim = x.shape
+    def forward(
+        self,
+        x,
+        cu_seqlens=None,
+        max_seqlen=None,
+        **kwargs,
+    ):
+        if cu_seqlens is not None:
+            # Unpadded / variable-length path.
+            #
+            # x shape:
+            # (total_valid_tokens, hidden_size)
+            total_tokens, hidden_dim = x.shape
+
+            qkv = self.Wqkv(x)
+            qkv = qkv.view(
+                total_tokens,
+                3,
+                self.num_heads,
+                self.head_dim,
+            )
+
+            # Prefer the actual longest sequence in this batch.
+            if max_seqlen is None:
+                max_seqlen = self.max_seqlen
+
+            qkv = self.rotary_embedding(
+                qkv,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+
+            y = self.self_attn(
+                qkv,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+
+            y = y.reshape(total_tokens, hidden_dim)
+            return self.out_proj(y)
+
+        # Existing padded path.
+        batch_size, seqlen, hidden_dim = x.shape
 
         qkv = self.Wqkv(x)
         qkv = qkv.view(
-            bs, seqlen, 3, self.num_heads, self.head_dim
-        )  # (bs, seqlen, dim) -> (bs, seqlen, 3, nh, hd)
-
-        qkv = self.rotary_embedding(
-            qkv, cu_seqlens=cu_seqlens, max_seqlen=self.max_seqlen
+            batch_size,
+            seqlen,
+            3,
+            self.num_heads,
+            self.head_dim,
         )
 
-        y = self.self_attn(qkv, cu_seqlens=cu_seqlens, max_seqlen=self.max_seqlen)
-        y = y.reshape(bs, seqlen, -1)
-        y = self.out_proj(y)
-        return y
+        qkv = self.rotary_embedding(
+            qkv,
+            cu_seqlens=None,
+            max_seqlen=seqlen,
+        )
+
+        y = self.self_attn(qkv)
+
+        y = y.reshape(batch_size, seqlen, hidden_dim)
+        return self.out_proj(y)

--- a/bonsai/modules/networks/components/rope_fa.py
+++ b/bonsai/modules/networks/components/rope_fa.py
@@ -1,8 +1,4 @@
-"""Rotary embedding supporting both padded and packed-varlen qkv
-
-Padded mode (cu_seqlens=None):
-            qkv (batch, seqlen, 3, nheads, headdim), cu_seqlens=None
-            -> parent RotaryEmbedding.forward
+"""Rotary embedding supporting packed-varlen qkv
 
 Varlen mode (cu_seqlens is not None):
             qkv (total_tokens, 3, nheads, headdim) + cu_seqlens (batch+1,)
@@ -17,14 +13,9 @@ class FlashRotaryEmbedding(RotaryEmbedding):
     def forward(
         self, qkv: torch.Tensor, cu_seqlens: torch.Tensor, max_seqlen: int
     ) -> torch.Tensor:
-        if cu_seqlens is None:
-            assert qkv.dim() == 5, (
-                f"padded qkv must be (batch, seqlen, 3, nheads, headdim), got {tuple(qkv.shape)}"
-            )
-            return super().forward(qkv, max_seqlen=max_seqlen)
-
+        """Apply rotary embedding to qkv in varlen mode."""
         assert qkv.dim() == 4, (
-            f"varlen qkv must be (total_tokens, 3, nheads, headdim), got {tuple(qkv.shape)}"
+            f"varlen qkv must be (total_tokens, 3, nheads, headdim), got {qkv.shape}"
         )
         assert max_seqlen is not None, "varlen mode requires max_seqlen"
         self._update_cos_sin_cache(max_seqlen, device=qkv.device, dtype=qkv.dtype)


### PR DESCRIPTION
Closes issue #345

Implements unpadding for FlashAttention, packing sequences after the embedding layer and restoring the padded representation after the transformer layers.

The PR changes four files:
1. `bonsai_nets.py` unpads FlashAttention inputs after embeddings and repads the output after the transformer layers.
2. `layer.py` propagates `cu_seqlens` and `max_seqlen` through transformer layers.
3. `mha_fa.py` changes FlashAttention to operate directly on packed variable-length sequences.
4. `rope_fa.py` updates rotary embeddings to operate on packed variable-length QKV tensors

Performance testing was conducted on the PHAIR Light population on worker02, with runs limited to 500 training batches and 0 validation batches to keep the experiments short and consistent across the two implementations.

Performance was evaluated against the padded baseline using DeviceStatsMonitor, PyTorch Profiler, and iteration speed, but these measurements gave mixed results and did not show a clear performance advantage from unpadding. However, testing the maximum stable batch size showed a clear benefit: the unpadding implementation could handle larger batches before OOM, demonstrating reduced memory pressure and improved memory efficiency (See table below).

| Batch size  | Unpadding implemented | Unpadding not implemented |
|-----|-----------------------|---------------------------|
| 320 | —                     | ✅ PASSED                 |
| 352 | —                     | ✅ PASSED                 |
| 384 | —                     | ❌ FAILED OOM                |
| 512 | ✅ PASSED             | ❌ FAILED  OOM                |
| 640 | ✅ PASSED             | —                         |
| 768 | ❌ FAILED OOM            | —                         |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved attention processing for variable-length sequences when FlashAttention is available.
  * Reduced padding overhead by packing inputs before attention and restoring outputs afterward.
* **Compatibility**
  * Added support for standard scaled dot-product attention when FlashAttention is unavailable.
  * Added validation for unsupported attention configurations.
* **Reliability**
  * Improved handling of sequence metadata and attention masks across transformer layers.
  * Preserved dropout behavior across attention processing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->