### PR TITLE
Added support for causal SDPA

### DIFF
--- a/bonsai/modules/networks/bonsai_nets.py
+++ b/bonsai/modules/networks/bonsai_nets.py
@@ -32,6 +32,10 @@ class BonsaiBase(nn.Module):
             raise ImportError(
                 "flash_attn is not available. Please install flash-attn or use `attn_type='sdpa'` instead."
             )
+        if attn_type not in ["flash", "sdpa"]:
+            raise ValueError(
+                f"Invalid attn_type '{attn_type}'. Must be one of ['flash', 'sdpa']."
+            )
         super().__init__()
         self.embeddings = EhrEmbeddings(
             vocab_size=vocab_size,
@@ -82,10 +86,6 @@ class BonsaiBase(nn.Module):
             return self.forward_flash(x, batch["attention_mask"])
         elif self.hparams["attn_type"] == "sdpa":
             return self.forward_sdpa(x, batch["attention_mask"])
-        else:
-            raise ValueError(
-                f"Invalid attention type: {self.hparams['attn_type']}. Only 'flash' and 'sdpa' are supported."
-            )
 
     def forward_sdpa(self, x, attn_mask):
         attn_mask = attn_mask[:, None, None, :]

--- a/bonsai/modules/networks/bonsai_nets.py
+++ b/bonsai/modules/networks/bonsai_nets.py
@@ -80,11 +80,11 @@ class BonsaiBase(nn.Module):
 
         if self.hparams["attn_type"] == "flash":
             return self.forward_flash(x, batch["attention_mask"])
-        elif self.hparams["attn_type"] == "sdpa" and not self.hparams["causal"]:
+        elif self.hparams["attn_type"] == "sdpa":
             return self.forward_sdpa(x, batch["attention_mask"])
         else:
             raise ValueError(
-                f"Invalid attention type: {self.hparams['attn_type']}. Only 'flash' and non-causal 'sdpa' are supported."
+                f"Invalid attention type: {self.hparams['attn_type']}. Only 'flash' and 'sdpa' are supported."
             )
 
     def forward_sdpa(self, x, attn_mask):

--- a/bonsai/modules/networks/bonsai_nets.py
+++ b/bonsai/modules/networks/bonsai_nets.py
@@ -85,11 +85,14 @@ class BonsaiBase(nn.Module):
         if self.hparams["attn_type"] == "flash":
             return self.forward_flash(x, batch["attention_mask"])
         elif self.hparams["attn_type"] == "sdpa":
-            return self.forward_sdpa(x, batch["attention_mask"])
+            return self.forward_sdpa(
+                x,
+                attn_mask=batch["attention_mask"][:, None, None, :]
+                if not self.hparams["causal"]
+                else None,  # Causal SDPA needs attn_mask to be None
+            )
 
     def forward_sdpa(self, x, attn_mask):
-        attn_mask = attn_mask[:, None, None, :]
-
         for layer in self.layers:
             x = layer(x, attn_mask=attn_mask)
 

--- a/bonsai/modules/networks/components/mha.py
+++ b/bonsai/modules/networks/components/mha.py
@@ -11,6 +11,8 @@ class SDPA(nn.Module):
         self.attention_dropout = attention_dropout
 
     def forward(self, q, k, v, attn_mask=None):
+        if self.causal:
+            attn_mask = None
         return F.scaled_dot_product_attention(
             q,
             k,

--- a/bonsai/modules/networks/components/mha.py
+++ b/bonsai/modules/networks/components/mha.py
@@ -11,8 +11,6 @@ class SDPA(nn.Module):
         self.attention_dropout = attention_dropout
 
     def forward(self, q, k, v, attn_mask=None):
-        if self.causal:
-            attn_mask = None
         return F.scaled_dot_product_attention(
             q,
             k,


### PR DESCRIPTION
Rather than forcing non-causal SDPA, we can just remove the `attn_mask` (SDPA doesn't allow `causal=True` and `attn_mask` to be set). 

Alternatively, we can have an if/else clause in the `forward_sdpa` that sets `attn_mask = None` instead of doing it in `mha`, but I don't believe the user (we) care for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved causal attention handling for more reliable sequence processing.
  * Causal mode now correctly manages attention masks.
  * Invalid attention configurations continue to provide clear validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->